### PR TITLE
Add basic support for proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/btcsuite/btcd v0.23.3
 	github.com/btcsuite/btcd/btcutil v1.1.2
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
-	github.com/fiatjaf/lightningd-gjson-rpc v1.6.1
+	github.com/fiatjaf/lightningd-gjson-rpc v1.6.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/fergusstrange/embedded-postgres v1.10.0 h1:YnwF6xAQYmKLAXXrrRx4rHDLih
 github.com/fergusstrange/embedded-postgres v1.10.0/go.mod h1:a008U8/Rws5FtIOTGYDYa7beVWsT3qVKyqExqYYjL+c=
 github.com/fiatjaf/lightningd-gjson-rpc v1.6.1 h1:gFU4Ekmn3iVQArKsvqr1W6V8YGUt+9iHT6+I2QUECq8=
 github.com/fiatjaf/lightningd-gjson-rpc v1.6.1/go.mod h1:DqVHlrgk0q0J08nbPBCwDVuB7vzPohRnrzuGZ0ct0fg=
+github.com/fiatjaf/lightningd-gjson-rpc v1.6.2 h1:QlnPE3piGCAd8qElWIPuVbDYq4E1WTspgwP01q3olrI=
+github.com/fiatjaf/lightningd-gjson-rpc v1.6.2/go.mod h1:DqVHlrgk0q0J08nbPBCwDVuB7vzPohRnrzuGZ0ct0fg=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"fmt"
 	"math/rand"
 
@@ -171,6 +172,17 @@ func main() {
 		},
 		OnInit: func(p *plugin.Plugin) {
 			network = p.Network
+
+			proxy := p.Configuration.Get("proxy")
+			always_use_proxy := p.Configuration.Get("always_use_proxy").Bool()
+
+			if proxy.Exists() && always_use_proxy {
+				socks_proxy := "socks5://" + proxy.Get("address").String() + ":" + proxy.Get("port").String()
+				p.Logf("using proxy: %s", socks_proxy)
+
+				os.Setenv("HTTP_PROXY", socks_proxy)
+				os.Setenv("HTTPS_PROXY", socks_proxy)
+			}
 
 			// we will try to use a local bitcoind
 			user := p.Args.Get("bitcoin-rpcuser").String()


### PR DESCRIPTION
Get the proxy configuration from clightning configuration file and use it for all http/https connections.

We need to proxy all http/https trustedcoin connections via Tor in a nix-bitcoin project, see the PR here:
- https://github.com/fort-nix/nix-bitcoin/pull/597#issuecomment-1503099388

We currently set the `Environment="HTTPS_PROXY=socks5://127.0.0.1:9050"` and `Environment="HTTP_PROXY=socks5://127.0.0.1:9050"` env variables in a clightning systemd service configuration as a workaround:
- https://github.com/fort-nix/nix-bitcoin/pull/597/files#diff-05a8747f05b6c0eea6aa51bb5622bd456447d0b7d2c1b7c7ceaef43e7d3d9aebR22