### PR TITLE
support network `regtest`

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,6 +109,8 @@ func main() {
 						bip70network = "test"
 					case "signet":
 						bip70network = "signet"
+					case "regtest":
+						bip70network = "regtest"
 					case "liquid":
 						bip70network = "liquidv1"
 					}


### PR DESCRIPTION
Without this, clightning fails with the following error when running on regtest:
```
Wrong network! Our Bitcoin backend is running on '', but we expect 'regtest'.
```