### PR TITLE
Fix estimatefees

### DIFF
--- a/estimatefees.go
+++ b/estimatefees.go
@@ -46,6 +46,8 @@ func getFeeRates() (*EstimatedFees, error) {
 			}
 			estimated.MinAcceptable = intp(*estimated.MutualClose / 2)
 			estimated.MaxAcceptable = intp(*estimated.UnilateralClose * 100)
+
+			return estimated, nil
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/nbd-wtf/trustedcoin/issues/20, by making the `estimatefees` response conformant to its [current spec](https://github.com/ElementsProject/lightning/blob/master/doc/developers-guide/plugin-development/bitcoin-backend.md#estimatefees).

Sample output from a test run of lightningd v24.05 with this branch of the plugin:

```
fff8229c9007:~# lightningd
2024-07-11T20:25:10.873Z INFO    lightningd: v24.05
2024-07-11T20:25:10.893Z INFO    plugin-manager: /usr/local/libexec/c-lightning/plugins/bcli: disabled via disable-plugin
2024-07-11T20:25:10.922Z INFO    plugin-clnrest: Killing plugin: disabled itself: No python3 binary found
2024-07-11T20:25:10.922Z INFO    plugin-wss-proxy: Killing plugin: disabled itself: No python3 binary found
plugin-trustedcoin  initialized plugin v0.6.1
plugin-trustedcoin  bitcoind RPC settings not detected (looked for 'bitcoin-rpcuser', 'bitcoin-rpcpassword' and optionally 'bitcoin-rpcconnect' and 'bitcoin-rpcport'), will only use block explorers.
plugin-trustedcoin tip: 851730
plugin-trustedcoin returning block 851715, 000000000000000000024b364e…, 1596979 bytes
2024-07-11T20:25:35.287Z INFO    plugin-chanbackup: Creating Emergency Recovery
2024-07-11T20:25:35.290Z INFO    plugin-bookkeeper: Creating database
plugin-trustedcoin tip: 851730
2024-07-11T20:25:35.317Z INFO    lightningd: --------------------------------------------------
2024-07-11T20:25:35.317Z INFO    lightningd: Server started with public key 036ed85c1570e412df0e769a6e6620d0cc0b95cd323cc52342e23f212bfc1d010c, alias HAPPYSCAN (color #036ed8) and lightningd v24.05
plugin-trustedcoin returning block 851716, 00000000000000000000144d67…, 1571827 bytes
plugin-trustedcoin returning block 851717, 00000000000000000000a73dce…, 1711570 bytes
plugin-trustedcoin returning block 851718, 000000000000000000032381f1…, 1701511 bytes
plugin-trustedcoin returning block 851719, 000000000000000000037f6e52…, 1713696 bytes
...
```